### PR TITLE
Revoke access to forgot password page for logged in users

### DIFF
--- a/src/__tests__/components/ResetPassword/ResetPasswordPage.test.js
+++ b/src/__tests__/components/ResetPassword/ResetPasswordPage.test.js
@@ -35,6 +35,9 @@ describe("Reset Password Form", () => {
         hash: "",
         search: "",
         state: undefined
+      },
+      history: {
+        push: jest.fn()
       }
     };
 
@@ -46,6 +49,8 @@ describe("Reset Password Form", () => {
     let useEffect;
 
     let wrapper;
+
+    let wrapperLoggedIn;
 
     const mockUseEffect = () => {
       useEffect.mockImplementationOnce(f => f());
@@ -116,7 +121,15 @@ describe("Reset Password Form", () => {
       expect(wrapper.find("form").length).toBe(1);
       done();
     });
-
+    
+    test("should test logged in access to forgotPassword", done => {
+      window.localStorage.getItem = () => true;
+      wrapperLoggedIn = renderResetPassword();
+      const { history } = wrapperLoggedIn.props();
+      const { push } = history;
+      expect(push).toHaveBeenCalledWith('/dashboard'); 
+      done();
+    });
   });
 
   describe("Errror in ResetFormTemplate, ResetEmailSentTemplate and PasswordResetFormTemplate", () => {

--- a/src/components/ResetPassword/ResetPasswordPage.js
+++ b/src/components/ResetPassword/ResetPasswordPage.js
@@ -35,6 +35,9 @@ export function ResetPasswordPage({
   message,
   history
 }) {
+  if(localStorage.getItem('bareFootToken')) {
+    history.push('/dashboard');
+  }
   const [email, setEmail] = useState();
   const [password, setPassword] = useState();
   const [newPassword, setNewPassword] = useState();


### PR DESCRIPTION
#### What does this PR do?
Fixes issue #48 
#### Description of Task to be completed?
When logged-in users try to access `/forgotPassword`, they will be redirected to their dashboard
closes #48 
#### How should this be manually tested?
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A