### PR TITLE
#63 bug-fix(accommodation): fixing verious issues in the application

### DIFF
--- a/src/components/accommodations.js
+++ b/src/components/accommodations.js
@@ -106,7 +106,7 @@ export class Accommodations extends Component {
         
         return (
             <>
-            <Meta title="Acommodations"/>
+            <Meta title="Accommodations"/>
                 <div className='grid'>
                     <div className='col-10 offset-3'>
                         {isAllowed ? button : '' }

--- a/src/components/shared/Navbar.js
+++ b/src/components/shared/Navbar.js
@@ -99,7 +99,7 @@ export const Navbar = ({ history, location, role }) => {
   return (
     <>
       <nav className="navbar">
-        <a className="navbar-brand" href="/home">
+        <a className="navbar-brand" href="/dashboard">
           <img alt="BareFoot Nomad" src={logo} />
         </a>
         <ul className="menu-items">

--- a/src/components/shared/accommodationCard.js
+++ b/src/components/shared/accommodationCard.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-target-blank */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -8,7 +9,7 @@ const accommodationCard = (props) => {
     const {id, name, url, handleImageClick} = props;
     return(<div className="acc-card col-3" onClick={()=>handleImageClick(id, name)}>
         <img src={ url ? url[0] : 'https://res.cloudinary.com/drayzii/image/upload/v1573796111/no-image-found-360x260_xvpnuj.png'} alt="Accommodation"/>
-<p><a href={`/accommodation/${id}`}>{name}</a></p> 
+<p><a href={`/accommodation/${id}`} target="_blank">{name}</a></p> 
     </div>);
 };
 accommodationCard.propTypes = {

--- a/src/styles/bookRoomPage.scss
+++ b/src/styles/bookRoomPage.scss
@@ -42,10 +42,15 @@
   justify-content: center;
   overflow-y: scroll;
   .acc-card {
+    width: 30%;
+    min-width: 300px;
     display: inline-block;
     margin: 20px;
     * {
       width: 100%;
+    }
+    img {
+      max-height: 30vh;
     }
   }
 }


### PR DESCRIPTION


#### What does this PR do?
Closes #63 
#### Description of Task to be completed?
- accommodations page should have a title `Accommodations` instead of ~Acommodations~
- accommodations link on book rooms page should open a new tab for the user to be able to stay on the page
- barefoot logo on the nav bar should redirect to `/dashboard` instead of ~/home~ which no longer exists
#### How should this be manually tested?
- clone the repo
- start the server
- log in and navigate to '/accommodations'
==> the tab title should be 'Accommodations'
- try booking a room, on clicking on accommodation name,
==> a new tab should opened that leads to that specific accommodation.
