### PR TITLE
bug-fix(fixing the booking): should toast the errors but stay on book…

### DIFF
--- a/src/__tests__/components/BookRoomPage.test.js
+++ b/src/__tests__/components/BookRoomPage.test.js
@@ -73,7 +73,7 @@ describe('Unit tests', ()=>{
         const wrapper = render();
         wrapper.setProps({bookedroom: {error: {status: 403, message: 'error message'}, data: null}});
         const {push} = wrapper.instance().props.history;
-        expect(push).toHaveBeenCalledWith('/home');
+        expect(push).toHaveBeenCalledWith('/dashboard');
     });
 
     it('should handle 404 errors', () => {
@@ -87,14 +87,14 @@ describe('Unit tests', ()=>{
         const wrapper = render();
         wrapper.setProps({bookedroom: {error: {status: 409, message: 'error message'}, data: null}});
         const {push} = wrapper.instance().props.history;
-        expect(push).toHaveBeenCalledWith('/home');
+        expect(push).toHaveBeenCalledWith('/requests');
     });
 
     it('should handle 500 and other errors', () => {
         const wrapper = render();
         wrapper.setProps({bookedroom: {error: {status: 500, message: 'error message'}, data: null}});
         const {push} = wrapper.instance().props.history;
-        expect(push).toHaveBeenCalledWith('/home');
+        expect(push).toHaveBeenCalledTimes(0);
     });
     it('should handle cancel and go the previous page', () => {
         const wrapper = render();

--- a/src/__tests__/components/commentsComponent.test.js
+++ b/src/__tests__/components/commentsComponent.test.js
@@ -33,6 +33,7 @@ describe('RequestView Component', () => {
         getComment={jest.fn()}
         postComment={jest.fn()}
         requestId={1}
+        status='Pending'
         />,
       );
     });

--- a/src/__tests__/redux/reducers/accommodation.test.js
+++ b/src/__tests__/redux/reducers/accommodation.test.js
@@ -75,7 +75,7 @@ describe('Accommodations Reducers', () => {
     const payload = {
       status: 200,
       user: {
-          role: 'supplier',
+          role: 'Accommodation Supplier',
           id: 2
       },
       accommodations: [

--- a/src/components/AccessForbiddenPage.js
+++ b/src/components/AccessForbiddenPage.js
@@ -13,7 +13,7 @@ function AccessForbiddenPage(props) {
                     Forbidden<span className="blink">_</span>
                 </div>
                 <div className="txt m-top-2">
-                    <a href="/home">Go home</a>
+                    <a href="/dashboard">Go home</a>
                 </div>
             </div>
         </>

--- a/src/components/BookRoomPage.js
+++ b/src/components/BookRoomPage.js
@@ -73,16 +73,15 @@ class BookRoom extends Component {
                     history.push('/login');
                 } else if(status === 403) {
                     toast.error(message);
-                    history.push('/home');
+                    history.push('/dashboard');
                 } else if(status === 404) {
                     toast.error(message);
                     history.push('/requests');
                 } else if(status === 409){
                     toast.error(message);
-                    history.push('/home');
+                    history.push('/requests');
                 } else {
                     toast.error(message);
-                    history.push('/home');
                 }
             }
         }

--- a/src/components/ViewRequest.js
+++ b/src/components/ViewRequest.js
@@ -194,10 +194,7 @@ export class ViewRequest extends Component {
                 </div>
                 <div className="travel-reason-2-container col-7">
                     <TravelReason reason={payload.reason}/>
-                    { payload.status === 'Pending' ?
-                        <CommentsCompoment requestId={match.params.id}/>
-                        : ''
-                    }
+                    <CommentsCompoment status={payload.status} requestId={match.params.id}/>
                 </div>
                 <div className='col-1' />
             </div> : 

--- a/src/components/shared/commentsCompoment.js
+++ b/src/components/shared/commentsCompoment.js
@@ -48,7 +48,7 @@ class CommentsCompoment extends Component {
 
     render() {
       const{ comment, markup, error } = this.state;
-      const { comments, profile } =this.props;
+      const { comments, profile, status } =this.props;
       const obj = comments.comments;
       let display;
         if(Object.keys(obj).length === 0 && obj.constructor === Object){
@@ -77,10 +77,12 @@ class CommentsCompoment extends Component {
             <>
                     <div className="comment-container">
                     <h3 className="comment-title">Comments</h3>
-                    <form onSubmit={this.handleSubmit}>
-                      <TextArea value={comment} markup={markup} name='comment' onChange={(e) => this.handleChange(e)} error='' />
-                      <button className="btn btn-secondary" type="submit">Add Comment</button>
-                    </form>
+                    { status === 'Pending'?
+                      <form onSubmit={this.handleSubmit}>
+                        <TextArea value={comment} markup={markup} name='comment' onChange={(e) => this.handleChange(e)} error='' />
+                        <button className="btn btn-secondary" type="submit">Add Comment</button>
+                      </form> : ''
+                    }
                     <div className="comments">
                     {display}
                     </div>

--- a/src/components/shared/tableComponent.js
+++ b/src/components/shared/tableComponent.js
@@ -65,7 +65,7 @@ export default function TableComponent({ items, totalRequests, requestsPerPage, 
                     </td>
                     <td className="table-col" id={request.id}>
                         {request.travelDate.map((item, _index) =>
-                        <li key={_index.toString()}>
+                        <li id={request.id} key={_index.toString()}>
                             {moment(item).format("MMM Do YY")}
                         </li>)}</td>
                     <td className="table-col" id={request.id}>{moment(request.returnDate).format("MMM Do YY") === 'Invalid date' ? '-' : moment(request.returnDate).format("MMM Do YY")}</td>

--- a/src/redux/reducers/accommodations.js
+++ b/src/redux/reducers/accommodations.js
@@ -9,7 +9,7 @@ export default (state = initialState, action) => {
   const { type, payload} = action;
   switch (type) {
     case GET_ACCOMMODATIONS_SUCCESS:
-      if(payload.user.role === 'supplier') {
+      if(payload.user.role === 'Accommodation Supplier') {
         const supAccommodations = payload.accommodations.filter((acc) => acc.owner === payload.user.id );
         return {
           ...state,


### PR DESCRIPTION

#### What does this PR do?
- fixes some booking and accommodation issues
#### Description of Task to be completed?
- before, the booking errors posted to '/home' which does not exist
- they now stay to the booking page
- Accommodation supplier can only see accommodations that they added
#### How should this be manually tested?
- clone the repo and start the server
- log in as a travel admin and add accommodation.
==> you should only your added accommodation
- log in as a requester and book a room. if any booking error arises, you should see a toast but stay on the same page
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A